### PR TITLE
PHP-VCR annotation vs. explicit calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "phpunit/phpunit": "~3.0",
         "mockery/mockery": "dev-master",
-        "php-vcr/php-vcr": "1.1.7",
+        "php-vcr/php-vcr": "~1.1",
         "php-vcr/phpunit-testlistener-vcr": "dev-master"
     },
     "config": {

--- a/test/Kirschbaum/DrupalBehatRemoteAPIClient/Tests/DrupalAuthTest.php
+++ b/test/Kirschbaum/DrupalBehatRemoteAPIClient/Tests/DrupalAuthTest.php
@@ -11,15 +11,11 @@ class DrupalAuthTest extends BaseTest {
      */
     public function should_pass_basic_auth_and_drupal_auth_with_username_and_password()
     {
-        VCR::turnOn();
-        VCR::insertCassette('should_pass_basic_auth_and_drupal_auth_with_username_and_password.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
         $results = $client->api('nodes')->createNode($this->test_node_params());
         $this->assertObjectHasAttribute('nid', $results);
-        VCR::eject();
-        VCR::turnOff();
     }
 
 } 

--- a/test/Kirschbaum/DrupalBehatRemoteAPIClient/Tests/NodeTest.php
+++ b/test/Kirschbaum/DrupalBehatRemoteAPIClient/Tests/NodeTest.php
@@ -11,15 +11,11 @@ class NodeTest extends BaseTest {
      */
     public function should_create_node_and_return_object_with_node_id()
     {
-        VCR::turnOn();
-        VCR::insertCassette('should_create_node_and_return_object_with_node_id.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
         $results = $client->api('nodes')->createNode($this->test_node_params());
         $this->assertObjectHasAttribute('nid', $results);
-        VCR::eject();
-        VCR::turnOff();
     }
 
     /**
@@ -28,25 +24,19 @@ class NodeTest extends BaseTest {
      */
     public function should_delete_node_and_return_empty_array()
     {
-        VCR::turnOn();
         VCR::insertCassette('should_create_node_and_return_object_with_node_id.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
         $nodeResponse = $client->api('nodes')->createNode($this->test_node_params());
         $this->assertObjectHasAttribute('nid', $nodeResponse);
-        VCR::eject();
-        VCR::turnOff();
 
-        VCR::turnOn();
         VCR::insertCassette('should_delete_node_and_return_empty_array.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
         $results = $client->api('nodes')->deleteNode($nodeResponse);
         $this->assertEmpty($results);
-        VCR::eject();
-        VCR::turnOff();
     }
 
     /**
@@ -56,16 +46,12 @@ class NodeTest extends BaseTest {
      */
     public function should_take_exception_when_test_sets_field_format_that_doesnt_exist()
     {
-        VCR::turnOn();
-        VCR::insertCassette('should_take_exception_when_test_sets_field_format_that_doesnt_exist.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
         $nodeRequest = $client->api('nodes');
         $nodeRequest->setDrupalFilterFormat('non_existent');
         $results = $nodeRequest->createNode($this->test_node_params());
-        VCR::eject();
-        VCR::turnOff();
     }
 
     /**
@@ -76,16 +62,12 @@ class NodeTest extends BaseTest {
      */
     public function should_take_exception_when_incorrect_credentials_are_provided()
     {
-        VCR::turnOn();
-        VCR::insertCassette('should_take_exception_when_incorrect_credentials_are_provided.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $pw = 'wrong';
         $client->authenticate($this->username, $pw, 'http_drupal_login');
         $nodeRequest = $client->api('nodes');
         $results = $nodeRequest->createNode($this->test_node_params());
-        VCR::eject();
-        VCR::turnOff();
     }
 
     /**
@@ -96,14 +78,6 @@ class NodeTest extends BaseTest {
      */
     public function should_take_exception_when_too_many_terms_are_provided()
     {
-       // Having trouble with URL encoding match: https://github.com/php-vcr/php-vcr/issues/66
-       VCR::configure()
-         ->addRequestMatcher('url', function ($first, $second)
-         {
-             return $second->getPath() == $first->getPath();
-         });
-        VCR::turnOn();
-        VCR::insertCassette('should_take_exception_when_too_many_terms_are_provided.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
@@ -111,8 +85,6 @@ class NodeTest extends BaseTest {
         $node = $this->test_node_params();
         $node->field_tags = 'Tag one, Tag two';
         $results = $nodeRequest->createNode($node);
-        VCR::eject();
-        VCR::turnOff();
     }
 
 }

--- a/test/Kirschbaum/DrupalBehatRemoteAPIClient/Tests/TermTest.php
+++ b/test/Kirschbaum/DrupalBehatRemoteAPIClient/Tests/TermTest.php
@@ -11,15 +11,11 @@ class TermTest extends BaseTest {
      */
     public function should_create_term_with_vid_and_return_object_with_term_id()
     {
-        VCR::turnOn();
-        VCR::insertCassette('should_create_term_with_vid_and_return_object_with_term_id.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
         $results = $client->api('term')->termCreate($this->test_term_params());
         $this->assertObjectHasAttribute('tid', $results);
-        VCR::eject();
-        VCR::turnOff();
     }
 
     /**
@@ -28,8 +24,6 @@ class TermTest extends BaseTest {
      */
     public function should_create_term_based_on_vocabulary_machine_name()
     {
-        VCR::turnOn();
-        VCR::insertCassette('should_create_term_based_on_vocabulary_machine_name.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
@@ -38,8 +32,6 @@ class TermTest extends BaseTest {
         $term->vocabulary_machine_name = 'tags';
         $results = $client->api('term')->termCreate($this->test_term_params());
         $this->assertObjectHasAttribute('tid', $results);
-        VCR::eject();
-        VCR::turnOff();
     }
 
     /**
@@ -48,8 +40,6 @@ class TermTest extends BaseTest {
      */
     public function should_create_term_based_on_vocabulary_name()
     {
-        VCR::turnOn();
-        VCR::insertCassette('should_create_term_based_on_vocabulary_name.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
@@ -58,8 +48,6 @@ class TermTest extends BaseTest {
         $term->vocabulary_machine_name = 'Tags';
         $results = $client->api('term')->termCreate($this->test_term_params());
         $this->assertObjectHasAttribute('tid', $results);
-        VCR::eject();
-        VCR::turnOff();
     }
 
     /**
@@ -70,8 +58,6 @@ class TermTest extends BaseTest {
      */
     public function should_take_exception_when_term_vocabulary_machine_name_is_defined_but_does_not_exist()
     {
-        VCR::turnOn();
-        VCR::insertCassette('should_take_exception_when_term_vocabulary_machine_name_is_defined_but_does_not_exist.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
@@ -79,8 +65,6 @@ class TermTest extends BaseTest {
         unset($term->vid);
         $term->vocabulary_machine_name = 'Does Not Exist';
         $term = $client->api('term')->termCreate($term);
-        VCR::eject();
-        VCR::turnOff();
     }
 
     /**
@@ -89,25 +73,19 @@ class TermTest extends BaseTest {
      */
     public function should_delete_term_and_return_empty_array()
     {
-        VCR::turnOn();
         VCR::insertCassette('should_create_term_and_return_object_with_term_id.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
         $term = $client->api('term')->termCreate($this->test_term_params());
         $this->assertObjectHasAttribute('tid', $term);
-        VCR::eject();
-        VCR::turnOff();
 
-        VCR::turnOn();
         VCR::insertCassette('should_delete_term_and_return_empty_array.json');
         $client = new Client();
         $client->setOption('base_url', $this->url);
         $client->authenticate($this->username, $this->password, 'http_drupal_login');
         $results = $client->api('term')->termDelete($term);
         $this->assertEmpty($results);
-        VCR::eject();
-        VCR::turnOff();
     }
 
 

--- a/test/Kirschbaum/DrupalBehatRemoteAPIClient/Tests/UserTest.php
+++ b/test/Kirschbaum/DrupalBehatRemoteAPIClient/Tests/UserTest.php
@@ -11,7 +11,6 @@ class UserTest extends BaseTest {
    */
   public function should_create_and_delete_user_and_return_empty_array()
   {
-    VCR::turnOn();
     VCR::insertCassette('should_create_user_and_return_user_id.json');
     $client = new Client();
     $client->setOption('base_url', $this->url);
@@ -19,28 +18,20 @@ class UserTest extends BaseTest {
     $user = $client->api('user')->userCreate($this->test_user_params());
     $this->assertObjectHasAttribute('uid', $user);
     $this->assertNotNull($user->uid);
-    VCR::eject();
-    VCR::turnOff();
 
-    VCR::turnOn();
     VCR::insertCassette('should_add_role_to_user.json');
     $client = new Client();
     $client->setOption('base_url', $this->url);
     $client->authenticate($this->username, $this->password, 'http_drupal_login');
     $results2 = $client->api('user')->userAddRole($user, 'authenticated user');
     $this->assertEquals('Role successfully added', $results2['message']);
-    VCR::eject();
-    VCR::turnOff();
 
-    VCR::turnOn();
     VCR::insertCassette('should_create_and_delete_user_and_return_empty_array.json');
     $client = new Client();
     $client->setOption('base_url', $this->url);
     $client->authenticate($this->username, $this->password, 'http_drupal_login');
     $results3 = $client->api('user')->userDelete($user);
     $this->assertEmpty($results3);
-    VCR::eject();
-    VCR::turnOff();
   }
 
 }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -13,7 +13,11 @@ if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader
         'php composer.phar install'.PHP_EOL);
 }
 
-\VCR\VCR::configure()->setStorage('json')->setCassettePath(__DIR__ .'/../test/fixtures');
+\VCR\VCR::configure()
+    ->setStorage('json')
+    ->setCassettePath(__DIR__ .'/../test/fixtures')
+    // Exclude 'headers' from request matching.
+    ->enableRequestMatchers(array('method', 'url', 'host', 'body', 'post_fields', 'query_string'));
 
 $loader->add('Kirschbaum\DrupalBehatRemoteAPIDriver\Tests', __DIR__);
 


### PR DESCRIPTION
I'm currently checking projects using PHP-VCR to see how people use the library and what can be improved in future PHP-VCR versions. So thank you for using PHP-VCR :-)

I noticed that in the tests there is both a) an `@vcr` annotation and b) a explicit call to `VCR:: turnOn()`. Were there any problems with using the annotation on its own?

Are there any problems or confusing things when using PHP-VCR you would like to share?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kirschbaum/drupal-behat-remote-api-driver/1)

<!-- Reviewable:end -->
